### PR TITLE
Add shortcut functions for applying headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,38 @@ Makes it possible to build the content of a `soap:Header` element.
 
 ```php
 use Soap\Xml\Builder\SoapHeaders;
-use Soap\Xml\Manipulator\PrependSoapHeaders;use VeeWee\Xml\Dom\Document;
-use function VeeWee\Xml\Dom\Builder\children;
+use Soap\Xml\Builder\SoapHeader;
+use Soap\Xml\Builder\Header\Actor;
+use Soap\Xml\Builder\Header\MustUnderstand;
+use Soap\Xml\Manipulator\PrependSoapHeaders;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Builder\namespaced_element;
 use function VeeWee\Xml\Dom\Builder\element;
 use function VeeWee\Xml\Dom\Builder\value;
 
 $doc = Document::fromXmlString($xml);
 $builder = new SoapHeaders(
-    children(
-        element('user', value('josbos')),
-        element('password', value('topsecret'))
-    )
+    new SoapHeader(
+        $targetNamespace,
+        'Auth',
+        children(
+            namespaced_element($targetNamespace, 'user', value('josbos')),
+            namespaced_element($targetNamespace, 'password', value('topsecret'))
+        ),
+        // Optionally, you can provide additional configurators for setting
+        // SOAP-ENV specific attributes:
+        Actor::next(),
+        new MustUnderstand()
+    ),
+    $header2,
+    $header3
 );
 
-$header = $doc->build($builder)[0];
+$headers = $doc->build($builder);
 
 // You can prepend the soap:Header as first element of the soap:envelope
 // Like this
-$doc->manipulate(new PrependSoapHeaders($header));
+$doc->manipulate(new PrependSoapHeaders(...$headers));
 ```
 
 ## Locator

--- a/src/Builder/Header/Actor.php
+++ b/src/Builder/Header/Actor.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Xml\Builder\Header;
+
+use DOMNode;
+use VeeWee\Xml\Dom\Builder\Builder;
+use VeeWee\Xml\Exception\RuntimeException;
+use function VeeWee\Xml\Dom\Builder\namespaced_attribute;
+use function VeeWee\Xml\Dom\Locator\Node\detect_document;
+use function VeeWee\Xml\Dom\Locator\root_namespace_uri;
+use function VeeWee\Xml\Dom\Predicate\is_element;
+
+final class Actor implements Builder
+{
+    public function __construct(
+        private string $actor
+    ) {
+    }
+
+    public static function next(): self
+    {
+        return new self('http://schemas.xmlsoap.org/soap/actor/next');
+    }
+
+    /**
+     * @psalm-suppress MissingThrowsDocblock
+     */
+    public function __invoke(DOMNode $node): DOMNode
+    {
+        $document = detect_document($node);
+        $namespace = root_namespace_uri()($document) ?? '';
+
+        if (!is_element($node)) {
+            throw RuntimeException::withMessage('Unable to add attribute to '.get_class($node));
+        }
+
+        return namespaced_attribute($namespace, 'soapenv:actor', $this->actor)($node);
+    }
+}

--- a/src/Builder/Header/MustUnderstand.php
+++ b/src/Builder/Header/MustUnderstand.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Soap\Xml\Builder\Header;
+
+use DOMNode;
+use VeeWee\Xml\Dom\Builder\Builder;
+use VeeWee\Xml\Exception\RuntimeException;
+use function VeeWee\Xml\Dom\Builder\namespaced_attribute;
+use function VeeWee\Xml\Dom\Locator\Node\detect_document;
+use function VeeWee\Xml\Dom\Locator\root_namespace_uri;
+use function VeeWee\Xml\Dom\Predicate\is_element;
+
+final class MustUnderstand implements Builder
+{
+    /**
+     * @psalm-suppress MissingThrowsDocblock
+     */
+    public function __invoke(DOMNode $node): DOMNode
+    {
+        $document = detect_document($node);
+        $namespace = root_namespace_uri()($document) ?? '';
+
+        if (!is_element($node)) {
+            throw RuntimeException::withMessage('Unable to add attribute to '.get_class($node));
+        }
+
+        return namespaced_attribute($namespace, 'soapenv:mustUnderstand', '1')($node);
+    }
+}

--- a/src/Builder/SoapHeader.php
+++ b/src/Builder/SoapHeader.php
@@ -1,15 +1,15 @@
-<?php declare(strict_types=1);
+<?php
+declare(strict_types=1);
 
 namespace Soap\Xml\Builder;
 
 use DOMElement;
 use DOMNode;
 use VeeWee\Xml\Dom\Builder\Builder;
+use function VeeWee\Xml\Dom\Builder\children;
 use function VeeWee\Xml\Dom\Builder\namespaced_element;
-use function VeeWee\Xml\Dom\Locator\Node\detect_document;
-use function VeeWee\Xml\Dom\Locator\root_namespace_uri;
 
-final class SoapHeaders implements Builder
+final class SoapHeader implements Builder
 {
     /**
      * @var list<callable(DOMNode): DOMElement>
@@ -20,8 +20,11 @@ final class SoapHeaders implements Builder
      * @no-named-arguments
      * @param list<callable(DOMNode): DOMElement> $configurators
      */
-    public function __construct(callable ... $configurators)
-    {
+    public function __construct(
+        private string $namespace,
+        private string $name,
+        callable ... $configurators,
+    ) {
         $this->configurators = $configurators;
     }
 
@@ -30,12 +33,12 @@ final class SoapHeaders implements Builder
      */
     public function __invoke(DOMNode $node): DOMNode
     {
-        $document = detect_document($node);
-
-        return namespaced_element(
-            root_namespace_uri()($document) ?? '',
-            'soap:Header',
-            ...$this->configurators
+        return children(
+            namespaced_element(
+                $this->namespace,
+                $this->name,
+                ...$this->configurators
+            )
         )($node);
     }
 }

--- a/src/Manipulator/PrependSoapHeaders.php
+++ b/src/Manipulator/PrependSoapHeaders.php
@@ -12,9 +12,15 @@ use VeeWee\Xml\Exception\RuntimeException;
 
 final class PrependSoapHeaders
 {
-    private DOMElement $soapHeaders;
+    /**
+     * @var list<DOMElement>
+     */
+    private array $soapHeaders;
 
-    public function __construct(DOMElement $soapHeaders)
+    /**
+     * @no-named-arguments
+     */
+    public function __construct(DOMElement ... $soapHeaders)
     {
         $this->soapHeaders = $soapHeaders;
     }
@@ -29,6 +35,10 @@ final class PrependSoapHeaders
         $doc = Document::fromUnsafeDocument($document);
         $envelope = $doc->locate(new SoapEnvelopeLocator());
 
-        return $envelope->insertBefore($this->soapHeaders, $envelope->firstChild);
+        foreach (array_reverse($this->soapHeaders) as $header) {
+            $envelope->insertBefore($header, $envelope->firstChild);
+        }
+
+        return $envelope;
     }
 }

--- a/tests/Unit/Builder/SoapHeaderTest.php
+++ b/tests/Unit/Builder/SoapHeaderTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace SoapTest\Xml\Unit\Builder;
+
+use PHPUnit\Framework\TestCase;
+use Soap\Xml\Builder\Header\Actor;
+use Soap\Xml\Builder\Header\MustUnderstand;
+use Soap\Xml\Builder\SoapHeader;
+use Soap\Xml\Builder\SoapHeaders;
+use Soap\Xml\Manipulator\PrependSoapHeaders;
+use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Builder\children;
+use function VeeWee\Xml\Dom\Builder\namespaced_element;
+use function VeeWee\Xml\Dom\Builder\value;
+use function VeeWee\Xml\Dom\Configurator\comparable;
+
+final class SoapHeaderTest extends TestCase
+{
+    public function test_it_can_create_a_header_element(): void
+    {
+        $tns = 'https://foo.bar';
+        $builder = new SoapHeaders(
+            new SoapHeader(
+                $tns,
+                'x:Auth',
+                children(
+                    namespaced_element($tns, 'x:user', value('josbos')),
+                    namespaced_element($tns, 'x:password', value('topsecret'))
+                )
+            ),
+            new SoapHeader($tns, 'Acting', Actor::next()),
+            new SoapHeader($tns, 'Understanding', new MustUnderstand())
+        );
+        $doc = Document::fromXmlFile(FIXTURE_DIR.'/empty-envelope.xml');
+        $headers = $doc->build($builder);
+        $doc->manipulate(new PrependSoapHeaders(...$headers));
+
+        $expected = <<<EOXML
+        <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"
+                       soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+            <soap:Header xmlns:soap="http://www.w3.org/2003/05/soap-envelope/">
+                <x:Auth xmlns:x="https://foo.bar">
+                    <x:user>josbos</x:user>
+                    <x:password>topsecret</x:password>
+                </x:Auth>
+                <Acting xmlns="https://foo.bar" soap:actor="http://schemas.xmlsoap.org/soap/actor/next" />
+                <Understanding xmlns="https://foo.bar" soap:mustUnderstand="1" />
+            </soap:Header>
+        </soap:Envelope>        
+        EOXML;
+
+
+        static::assertXmlStringEqualsXmlString(
+            Document::fromXmlString($expected, comparable())->toXmlString(),
+            Document::fromUnsafeDocument($doc->toUnsafeDocument(), comparable())->toXmlString()
+        );
+    }
+}

--- a/tests/Unit/Manipulator/PrependSoapHeadersTest.php
+++ b/tests/Unit/Manipulator/PrependSoapHeadersTest.php
@@ -7,9 +7,26 @@ use PHPUnit\Framework\TestCase;
 use Soap\Xml\Builder\SoapHeaders;
 use Soap\Xml\Manipulator\PrependSoapHeaders;
 use VeeWee\Xml\Dom\Document;
+use function VeeWee\Xml\Dom\Builder\attribute;
 
 final class PrependSoapHeadersTest extends TestCase
 {
+    public function test_it_can_prepend_no_header(): void
+    {
+        $doc = Document::fromXmlFile(FIXTURE_DIR.'/empty-envelope-with-body.xml');
+        $doc->manipulate(new PrependSoapHeaders());
+
+        $expected = <<<EOXML
+        <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"
+                       soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+            <soap:Body></soap:Body>
+        </soap:Envelope>
+        EOXML;
+
+        static::assertXmlStringEqualsXmlString($expected, $doc->toXmlString());
+    }
+
+
     public function test_it_can_prepend_a_soap_header_on_an_envelope(): void
     {
         $doc = Document::fromXmlFile(FIXTURE_DIR.'/empty-envelope-with-body.xml');
@@ -21,6 +38,28 @@ final class PrependSoapHeadersTest extends TestCase
         <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"
                        soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
             <soap:Header></soap:Header>
+            <soap:Body></soap:Body>
+        </soap:Envelope>
+        EOXML;
+
+        static::assertXmlStringEqualsXmlString($expected, $doc->toXmlString());
+    }
+
+    public function test_it_can_prepend_mulitple_soap_header_on_an_envelope(): void
+    {
+        $doc = Document::fromXmlFile(FIXTURE_DIR.'/empty-envelope-with-body.xml');
+        $headers = $doc->build(
+            new SoapHeaders(),
+            new SoapHeaders(attribute('id', '2')),
+        );
+
+        $doc->manipulate(new PrependSoapHeaders(...$headers));
+
+        $expected = <<<EOXML
+        <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope/"
+                       soap:encodingStyle="http://www.w3.org/2003/05/soap-encoding">
+            <soap:Header></soap:Header>
+            <soap:Header id="2"></soap:Header>
             <soap:Body></soap:Body>
         </soap:Envelope>
         EOXML;


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no
| Fixed issues | https://github.com/php-soap/psr18-transport/issues/3

#### Summary

This PR provides some builders for dealing with soap headers:

```php
$builder = new SoapHeaders(
    new SoapHeader(
        $targetNamespace,
        'x:Auth',
        children(
            namespaced_element($targetNamespace, 'x:user', value('josbos')),
            namespaced_element($targetNamespace, 'x:password', value('topsecret'))
        ),
        // Optionally, you can provide additional configurators for setting
        // SOAP-ENV specific attributes:
        Actor::next(),
        new MustUnderstand()
    ),
    $header2,
    $header3
);

$headers = $doc->build($builder);
$doc->manipulate(new PrependSoapHeaders(...$headers));
```
