### PR TITLE
Align SoapHeader(s) configurator type with namespaced_element

### DIFF
--- a/src/Builder/SoapHeader.php
+++ b/src/Builder/SoapHeader.php
@@ -12,13 +12,13 @@ use function VeeWee\Xml\Dom\Builder\namespaced_element;
 final class SoapHeader implements Builder
 {
     /**
-     * @var list<callable(Node): Element>
+     * @var list<callable(Element): Element>
      */
     private array $configurators;
 
     /**
      * @no-named-arguments
-     * @param list<callable(Node): Element> $configurators
+     * @param list<callable(Element): Element> $configurators Forwarded to {@see namespaced_element()}, hence the Element signature.
      */
     public function __construct(
         private string $namespace,

--- a/src/Builder/SoapHeaders.php
+++ b/src/Builder/SoapHeaders.php
@@ -12,13 +12,13 @@ use function VeeWee\Xml\Dom\Locator\root_namespace_uri;
 final class SoapHeaders implements Builder
 {
     /**
-     * @var list<callable(Node): Element>
+     * @var list<callable(Element): Element>
      */
     private array $configurators;
 
     /**
      * @no-named-arguments
-     * @param list<callable(Node): Element> $configurators
+     * @param list<callable(Element): Element> $configurators Forwarded to {@see namespaced_element()}, hence the Element signature.
      */
     public function __construct(callable ... $configurators)
     {


### PR DESCRIPTION
## What

Change the `$configurators` annotation in `SoapHeader` and `SoapHeaders` from `list<callable(Node): Element>` to `list<callable(Element): Element>`.

## Why

Both builders forward `$configurators` straight into veewee's `namespaced_element(...)`, whose signature is `list<callable(Element): Element>`. The previous `callable(Node): Element` annotation diverged from the delegation target, so under strict psalm passing `value()` (which is `callable(Element): Element`) to `SoapHeader` was rejected — even though the exact same `value()` works when passed directly to `namespaced_element`. php-soap's own README example tripped on this.

Matching the delegated signature fixes it. A short docblock note records that the `Element` signature mirrors `namespaced_element()`.

## Verification

- `vendor/bin/psalm` (errorLevel 1): No errors found, 100% type inference.
- `vendor/bin/phpunit`: OK — 26 tests, 30 assertions.